### PR TITLE
Remove ext/ctype dependency

### DIFF
--- a/src/LibDNS/Records/Types/IPv4Address.php
+++ b/src/LibDNS/Records/Types/IPv4Address.php
@@ -86,7 +86,7 @@ class IPv4Address extends Type
         }
 
         foreach ($octets as &$octet) {
-            if (strspn((string)$short, "0123456789") !== strlen($short) || $octet < 0x00 || $octet > 0xff) {
+            if (strspn((string)$octet, "0123456789") !== strlen($octet) || $octet < 0x00 || $octet > 0xff) {
                 throw new \UnexpectedValueException('Octet list is not a valid IPv4 address: invalid octet value ' . $octet);
             }
 

--- a/src/LibDNS/Records/Types/IPv4Address.php
+++ b/src/LibDNS/Records/Types/IPv4Address.php
@@ -86,7 +86,7 @@ class IPv4Address extends Type
         }
 
         foreach ($octets as &$octet) {
-            if (!ctype_digit((string) $octet) || $octet < 0x00 || $octet > 0xff) {
+            if (strspn((string)$short, "0123456789") !== strlen($short) || $octet < 0x00 || $octet > 0xff) {
                 throw new \UnexpectedValueException('Octet list is not a valid IPv4 address: invalid octet value ' . $octet);
             }
 

--- a/src/LibDNS/Records/Types/IPv6Address.php
+++ b/src/LibDNS/Records/Types/IPv6Address.php
@@ -151,7 +151,7 @@ class IPv6Address extends Type
         }
 
         foreach ($shorts as &$short) {
-            if (!ctype_digit((string) $short) || $short < 0x0000 || $short > 0xffff) {
+            if (strspn((string)$short, "0123456789") !== strlen($short) || $short < 0x0000 || $short > 0xffff) {
                 throw new \UnexpectedValueException('Short list is not a valid IPv6 address: invalid short value ' . $short);
             }
 


### PR DESCRIPTION
Using `ctype_digit()` in two places is unnecessary given the myriad ways to determine if a string contains only digits. Removing these calls it makes life much easier for those who build PHP with `--disable-all` (me ... all the time).