### PR TITLE
parse empty string NS reccord

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "daverandom/libdns",
+    "name": "domraider/libdns",
     "description": "DNS protocol implementation written in pure PHP",
     "license": "MIT",
     "keywords": ["dns"],


### PR DESCRIPTION
Currently the parser failed when parsing an empty string as NS response.

ie : 

```bash
$ dig ns iridosite.fr

; <<>> DiG 9.8.3-P1 <<>> ns iridosite.fr
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 25421
;; flags: qr rd ra; QUERY: 1, ANSWER: 2, AUTHORITY: 0, ADDITIONAL: 0

;; QUESTION SECTION:
;iridosite.fr.                  IN      NS

;; ANSWER SECTION:
iridosite.fr.           3600    IN      NS      ns1.agom.fr.
iridosite.fr.           3600    IN      NS      .

;; Query time: 32 msec
;; SERVER: 192.168.1.1#53(192.168.1.1)
;; WHEN: Mon Apr 10 14:27:42 2017
;; MSG SIZE  rcvd: 66
```