### PR TITLE
fixed labels parsing for escaped dot sequences

### DIFF
--- a/src/Records/TypeDefinitions/TypeDefinitionManager.php
+++ b/src/Records/TypeDefinitions/TypeDefinitionManager.php
@@ -226,6 +226,7 @@ class TypeDefinitionManager
             ],
             ResourceTypes::TXT => [ // RFC 1035
                 'txtdata+' => Types::CHARACTER_STRING,
+                '__toString' => static function() { return \implode('', \func_get_args()); },
             ],
             ResourceTypes::WKS => [ // RFC 1035
                 'address'  => Types::IPV4_ADDRESS,

--- a/src/Records/Types/DomainName.php
+++ b/src/Records/Types/DomainName.php
@@ -57,7 +57,24 @@ class DomainName extends Type
      */
     public function setValue($value)
     {
-        $this->setLabels(\explode('.', (string)$value));
+
+        $labels = preg_split(
+            '~(?<!\\\)' . preg_quote('.', '~') . '~',
+            (string) $value
+        );
+        $labels = array_map(
+            function ($label) {
+                return strtr(
+                    $label,
+                    [
+                        '\.' => '.',
+                    ]
+                );
+            },
+            $labels
+        );
+
+        $this->setLabels($labels);
     }
 
     /**


### PR DESCRIPTION
Hello!

I have found a problem occurring when you are using queries with escaped dots.

If you use `\.` sequence in your DNS query,  it is not parsed correctly as single label, but split into two labels, causing character `\` to be in the end of previous label and escaped by another `\`, resulting in `\\.`.

That is something else then you wanted to query in the first place.

These few lines of code are fixing the problem.

