### PR TITLE
Fix running on x86

### DIFF
--- a/src/Records/TypeDefinitions/TypeDefinitionManager.php
+++ b/src/Records/TypeDefinitions/TypeDefinitionManager.php
@@ -222,7 +222,7 @@ class TypeDefinitionManager
                 'priority' => Types::SHORT,
                 'weight'   => Types::SHORT,
                 'port'     => Types::SHORT,
-                'name'     => Types::DOMAIN_NAME | DomainName::FLAG_NO_COMPRESSION,
+                'name'     => Types::DOMAIN_NAME | (DomainName::FLAG_NO_COMPRESSION << 16),
             ],
             ResourceTypes::TXT => [ // RFC 1035
                 'txtdata+' => Types::CHARACTER_STRING,

--- a/src/Records/Types/DomainName.php
+++ b/src/Records/Types/DomainName.php
@@ -22,7 +22,7 @@ namespace LibDNS\Records\Types;
  */
 class DomainName extends Type
 {
-    const FLAG_NO_COMPRESSION = 0x80000000;
+    const FLAG_NO_COMPRESSION = 0x8000;
 
     /**
      * @var string

--- a/src/Records/Types/Long.php
+++ b/src/Records/Types/Long.php
@@ -38,10 +38,12 @@ class Long extends Type
     {
         $value = (int)$value;
 
-        if ($value < 0) {
-            throw new \UnderflowException('Long integer value must be in the range 0 - 4294967296');
-        } else if ($value > 0xffffffff) {
-            throw new \OverflowException('Long integer value must be in the range 0 - 4294967296');
+        if (4 !== \PHP_INT_SIZE) {
+            if ($value < 0) {
+                throw new \UnderflowException('Long integer value must be in the range 0 - 4294967296');
+            } else if ($value > 0xffffffff) {
+                throw new \OverflowException('Long integer value must be in the range 0 - 4294967296');
+            }
         }
 
         $this->value = $value;


### PR DESCRIPTION
`const FLAG_NO_COMPRESSION = 0x80000000;` is a float on 32 bit archs.

Since PHP 8.1, the following expression causes a deprecation:
`Types::DOMAIN_NAME | DomainName::FLAG_NO_COMPRESSION`

> PHP Deprecated:  Implicit conversion from float 2147483648 to int loses precision

This PR fixes the issue by shifting `FLAG_NO_COMPRESSION` by 16 bits.

It also skips a comparison in `Long::setValue()` that doesn't need to happen on 32b archs, where numbers are always 32b and can be negative even if they're meant to be understood as unsigned longs. Encoding/decoding doesn't care about the sign since they use pack/unpack().