### PR TITLE
Add explicit nullable type where required

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license": "MIT",
     "keywords": ["dns"],
     "require": {
-        "php": ">=7.0",
+        "php": ">=7.1",
         "ext-ctype": "*"
     },
     "autoload": {

--- a/src/Decoder/DecoderFactory.php
+++ b/src/Decoder/DecoderFactory.php
@@ -43,7 +43,7 @@ class DecoderFactory
      * @param bool $allowTrailingData
      * @return Decoder
      */
-    public function create(TypeDefinitionManager $typeDefinitionManager = null, bool $allowTrailingData = true): Decoder
+    public function create(?TypeDefinitionManager $typeDefinitionManager = null, bool $allowTrailingData = true): Decoder
     {
         $typeBuilder = new TypeBuilder(new TypeFactory);
 

--- a/src/Encoder/EncodingContext.php
+++ b/src/Encoder/EncodingContext.php
@@ -95,7 +95,7 @@ class EncodingContext
      * @param bool $truncate
      * @return bool
      */
-    public function isTruncated(bool $truncate = null): bool
+    public function isTruncated(?bool $truncate = null): bool
     {
         $result = $this->truncate;
 

--- a/src/Messages/Message.php
+++ b/src/Messages/Message.php
@@ -93,7 +93,7 @@ class Message
      * @param int $type Value of the message type field
      * @throws \RangeException When the supplied message type is outside the valid range 0 - 1
      */
-    public function __construct(RecordCollectionFactory $recordCollectionFactory, int $type = null)
+    public function __construct(RecordCollectionFactory $recordCollectionFactory, ?int $type = null)
     {
         $this->questionRecords = $recordCollectionFactory->create(RecordTypes::QUESTION);
         $this->answerRecords = $recordCollectionFactory->create(RecordTypes::RESOURCE);
@@ -186,7 +186,7 @@ class Message
      * @param bool $newValue The new value
      * @return bool The old value
      */
-    public function isAuthoritative(bool $newValue = null): bool
+    public function isAuthoritative(?bool $newValue = null): bool
     {
         $result = $this->authoritative;
 
@@ -203,7 +203,7 @@ class Message
      * @param bool $newValue The new value
      * @return bool The old value
      */
-    public function isTruncated(bool $newValue = null): bool
+    public function isTruncated(?bool $newValue = null): bool
     {
         $result = $this->truncated;
 
@@ -220,7 +220,7 @@ class Message
      * @param bool $newValue The new value
      * @return bool The old value
      */
-    public function isRecursionDesired(bool $newValue = null): bool
+    public function isRecursionDesired(?bool $newValue = null): bool
     {
         $result = $this->recursionDesired;
 
@@ -237,7 +237,7 @@ class Message
      * @param bool $newValue The new value
      * @return bool The old value
      */
-    public function isRecursionAvailable(bool $newValue = null): bool
+    public function isRecursionAvailable(?bool $newValue = null): bool
     {
         $result = $this->recursionAvailable;
 

--- a/src/Messages/MessageFactory.php
+++ b/src/Messages/MessageFactory.php
@@ -30,7 +30,7 @@ class MessageFactory
      * @param int $type Value of the message type field
      * @return \LibDNS\Messages\Message
      */
-    public function create(int $type = null): Message
+    public function create(?int $type = null): Message
     {
         return new Message(new RecordCollectionFactory, $type);
     }

--- a/src/Packets/Packet.php
+++ b/src/Packets/Packet.php
@@ -55,7 +55,7 @@ class Packet
      * @return string
      * @throws \OutOfBoundsException When the pointer position is invalid or the supplied length is negative
      */
-    public function read(int $length = null): string
+    public function read(?int $length = null): string
     {
         if ($this->pointer > $this->length) {
             throw new \OutOfBoundsException('Pointer position invalid');

--- a/src/Records/ResourceBuilderFactory.php
+++ b/src/Records/ResourceBuilderFactory.php
@@ -34,7 +34,7 @@ class ResourceBuilderFactory
      * @param \LibDNS\Records\TypeDefinitions\TypeDefinitionManager $typeDefinitionManager
      * @return \LibDNS\Records\ResourceBuilder
      */
-    public function create(TypeDefinitionManager $typeDefinitionManager = null): ResourceBuilder
+    public function create(?TypeDefinitionManager $typeDefinitionManager = null): ResourceBuilder
     {
         return new ResourceBuilder(
             new ResourceFactory,

--- a/src/Records/Types/BitMap.php
+++ b/src/Records/Types/BitMap.php
@@ -44,7 +44,7 @@ class BitMap extends Type
      * @param bool $newValue The new value
      * @return bool The old value
      */
-    public function isBitSet(int $index, bool $newValue = null): bool
+    public function isBitSet(int $index, ?bool $newValue = null): bool
     {
         $charIndex = (int)($index / 8);
         $bitMask = 0b10000000 >> ($index % 8);

--- a/src/Records/Types/Type.php
+++ b/src/Records/Types/Type.php
@@ -33,7 +33,7 @@ abstract class Type
      * @param string $value Internal value
      * @throws \RuntimeException When the supplied value is invalid
      */
-    public function __construct(string $value = null)
+    public function __construct(?string $value = null)
     {
         if (isset($value)) {
             $this->setValue($value);

--- a/src/Records/Types/TypeFactory.php
+++ b/src/Records/Types/TypeFactory.php
@@ -28,7 +28,7 @@ class TypeFactory
      * @param string $value
      * @return \LibDNS\Records\Types\Anything
      */
-    public function createAnything(string $value = null)
+    public function createAnything(?string $value = null)
     {
         return new Anything($value);
     }
@@ -39,7 +39,7 @@ class TypeFactory
      * @param string $value
      * @return \LibDNS\Records\Types\BitMap
      */
-    public function createBitMap(string $value = null)
+    public function createBitMap(?string $value = null)
     {
         return new BitMap($value);
     }
@@ -50,7 +50,7 @@ class TypeFactory
      * @param int $value
      * @return \LibDNS\Records\Types\Char
      */
-    public function createChar(int $value = null)
+    public function createChar(?int $value = null)
     {
         return new Char((string)$value);
     }
@@ -61,7 +61,7 @@ class TypeFactory
      * @param string $value
      * @return \LibDNS\Records\Types\CharacterString
      */
-    public function createCharacterString(string $value = null)
+    public function createCharacterString(?string $value = null)
     {
         return new CharacterString($value);
     }
@@ -105,7 +105,7 @@ class TypeFactory
      * @param int $value
      * @return \LibDNS\Records\Types\Long
      */
-    public function createLong(int $value = null)
+    public function createLong(?int $value = null)
     {
         return new Long((string)$value);
     }
@@ -116,7 +116,7 @@ class TypeFactory
      * @param int $value
      * @return \LibDNS\Records\Types\Short
      */
-    public function createShort(int $value = null)
+    public function createShort(?int $value = null)
     {
         return new Short((string)$value);
     }


### PR DESCRIPTION
Hello 👋 In the path to make Symfony fully compatible with the last PHP version, we'd like to upgrade the code to be deprecation free in PHP 8.4. Indeed, LibDNS is used by `amphp/dns`. This code update requires PHP 7.1, but I think it's safe to have this minimal requirement now. 🙂 

Related to https://github.com/symfony/symfony/issues/54180